### PR TITLE
fix: Move whole Plugin folder to Sources

### DIFF
--- a/Sources/cap2spm.swift
+++ b/Sources/cap2spm.swift
@@ -51,8 +51,6 @@ struct Cap2SPM: ParsableCommand {
         guard let capPlugin = capacitorPluginPackage.oldPlugin?.capacitorPlugin else { return }
 
         try modifySwiftFile(at: swiftFileURL, plugin: capPlugin)
-        try moveItemCreatingIntermediaryDirectories(at: swiftFileURL, to: capacitorPluginPackage.iosSrcDirectoryURL.appending(path: "Sources").appending(path: capPlugin.identifier).appending(path: swiftFileURL.lastPathComponent))
-        try moveItemCreatingIntermediaryDirectories(at: capacitorPluginPackage.iosSrcDirectoryURL.appending(path: "PluginTests"), to: capacitorPluginPackage.iosSrcDirectoryURL.appending(path: "Tests").appending(path: "\(capPlugin.identifier)Tests"))
         try generatePackageSwiftFile(at: packageSwiftFileURL, plugin: capPlugin)
 
         let fileList = [mFileURL, hFileURL]
@@ -61,6 +59,8 @@ struct Cap2SPM: ParsableCommand {
         } else {
             try fileDelete(of: fileList)
         }
+        try moveItemCreatingIntermediaryDirectories(at: capacitorPluginPackage.iosSrcDirectoryURL.appending(path: "Plugin"), to: capacitorPluginPackage.iosSrcDirectoryURL.appending(path: "Sources").appending(path: capPlugin.identifier))
+        try moveItemCreatingIntermediaryDirectories(at: capacitorPluginPackage.iosSrcDirectoryURL.appending(path: "PluginTests"), to: capacitorPluginPackage.iosSrcDirectoryURL.appending(path: "Tests").appending(path: "\(capPlugin.identifier)Tests"))
     }
 
     private func fileBackup(of fileURLs: [URL]) throws {


### PR DESCRIPTION
The previous PR only moved the plugin class to the Sources folder, but some plugins have multiple swift files, so this PR moves the whole Plugin folder into the Sources folder