### PR TITLE
fix: Remove unused files

### DIFF
--- a/Sources/cap2spm.swift
+++ b/Sources/cap2spm.swift
@@ -55,10 +55,14 @@ struct Cap2SPM: ParsableCommand {
         try moveItemCreatingIntermediaryDirectories(at: capacitorPluginPackage.iosSrcDirectoryURL.appending(path: "PluginTests"), to: capacitorPluginPackage.iosSrcDirectoryURL.appending(path: "Tests").appending(path: "\(capPlugin.identifier)Tests"))
         try generatePackageSwiftFile(at: packageSwiftFileURL, plugin: capPlugin)
 
-        let fileList = [mFileURL, hFileURL]
+        var fileList = [mFileURL, hFileURL]
         if shouldBackup {
             try fileBackup(of: fileList)
         } else {
+            let oldFiles = ["Plugin/Info.plist", "PluginTests/Info.plist", "Plugin.xcodeproj", "Plugin.xcworkspace", "Podfile"].compactMap {
+                capacitorPluginPackage.iosSrcDirectoryURL.appending(path: $0)
+            }
+            fileList.append(contentsOf: oldFiles)
             try fileDelete(of: fileList)
         }
     }


### PR DESCRIPTION
This PR removes some project/Xcode files that are no longer needed in SPM, only if no-backup is selected.

At the moment it fails to delete the test's Info.plist, https://github.com/ionic-team/capacitor-plugin-converter/pull/6 should be merged first as it moves the copying of the test folder after the backup/deletion of files.

