### PR TITLE
fix: library name should match the package name

### DIFF
--- a/Sources/CapacitorPluginTools/PackageFileGenerator.swift
+++ b/Sources/CapacitorPluginTools/PackageFileGenerator.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public class PackageFileGenerator {
     let packageName: String
-    let libName: String
+    let targetName: String
     let capRepoName = "capacitor-swift-pm"
     let capLocation = "https://github.com/ionic-team/capacitor-swift-pm.git"
     let capVersion = "7.0.0"
@@ -17,32 +17,32 @@ public class PackageFileGenerator {
                 platforms: [.iOS(.v14)],
                 products: [
                     .library(
-                        name: "\(libName)",
-                        targets: ["\(libName)"])
+                        name: "\(packageName)",
+                        targets: ["\(targetName)"])
                 ],
                 dependencies: [
                     .package(url: "\(capLocation)", from: "\(capVersion)")
                 ],
                 targets: [
                     .target(
-                        name: "\(libName)",
+                        name: "\(targetName)",
                         dependencies: [
                             .product(name: "Capacitor", package: "\(capRepoName)"),
                             .product(name: "Cordova", package: "\(capRepoName)")
                         ],
-                        path: "ios/Sources/\(libName)"),
+                        path: "ios/Sources/\(targetName)"),
                     .testTarget(
-                        name: "\(libName)Tests",
-                        dependencies: ["\(libName)"],
-                        path: "ios/Tests/\(libName)Tests")
+                        name: "\(targetName)Tests",
+                        dependencies: ["\(targetName)"],
+                        path: "ios/Tests/\(targetName)Tests")
                 ]
             )
             """
     }
 
-    public init(packageName: String, libName: String) {
+    public init(packageName: String, targetName: String) {
         self.packageName = packageName
-        self.libName = libName
+        self.targetName = targetName
     }
     
     public func generateFile(at fileURL: URL) throws {

--- a/Sources/CommandLineTool/cap2spm.swift
+++ b/Sources/CommandLineTool/cap2spm.swift
@@ -41,7 +41,7 @@ struct Cap2SPM: ParsableCommand {
         
         try capPlugin.modifySwiftFile(at: swiftFileURL)
         
-        let packageGenerator = PackageFileGenerator(packageName: podspec.podName, libName: capPlugin.identifier)
+        let packageGenerator = PackageFileGenerator(packageName: podspec.podName, targetName: capPlugin.identifier)
         
         try packageGenerator.generateFile(at: podspecFileURL)
         

--- a/Tests/CapacitorPluginToolsTests/PackageFileGenerator.swift
+++ b/Tests/CapacitorPluginToolsTests/PackageFileGenerator.swift
@@ -6,7 +6,7 @@ struct PackageFileGeneratorTests {
     let packageFileGenerator: PackageFileGenerator
     
     init() {
-        packageFileGenerator = PackageFileGenerator(packageName: "CapacitorAppPlugin", libName: "AppPlugin")
+        packageFileGenerator = PackageFileGenerator(packageName: "CapacitorAppPlugin", targetName: "AppPlugin")
     }
     
     @Test("Generates expected Package.swift Text")
@@ -23,7 +23,7 @@ struct PackageFileGeneratorTests {
             platforms: [.iOS(.v14)],
             products: [
                 .library(
-                    name: "AppPlugin",
+                    name: "CapacitorAppPlugin",
                     targets: ["AppPlugin"])
             ],
             dependencies: [


### PR DESCRIPTION
This PR sets the library name to be `packageName`.

Also renamed `libName` to `targetName` since it's actually the target name, as the library name should be the package name and `libName` is not only being used for targets.