### PR TITLE
fix: correct ios/ files check

### DIFF
--- a/Sources/CapacitorPluginTools/CapacitorPluginPackage.swift
+++ b/Sources/CapacitorPluginTools/CapacitorPluginPackage.swift
@@ -95,7 +95,7 @@ public class CapacitorPluginPackage {
         
         newFiles.removeAll(where: { $0 == "ios/Plugin" || $0 == "ios/Plugin/" })
         
-        if newFiles.contains(where: { $0 != "ios/"}) {
+        if !newFiles.contains(where: { $0 == "ios/"}) {
             newFiles.append("ios/Sources")
             newFiles.append("ios/Tests")
         }


### PR DESCRIPTION
The existing check is always adding `ios/Sources` and `ios/Tests` since the current check is always true, changed it to check that there is no `ios/` entry