### PR TITLE
fix: Update source files path on podspec file

### DIFF
--- a/Sources/CapacitorPluginTools/PodspecParser.swift
+++ b/Sources/CapacitorPluginTools/PodspecParser.swift
@@ -30,4 +30,10 @@ public struct PodspecParser {
             throw OldPluginParserError.podspecNameMissing
         }
     }
+
+    public func modifyPodspecFile(at fileURL: URL) throws {
+        var podspecText = try String(contentsOf: fileURL, encoding: .utf8)
+        podspecText = podspecText.replacingOccurrences(of: "/Plugin/", with: "/Sources/")
+        try podspecText.write(to: fileURL, atomically: true, encoding: .utf8)
+    }
 }

--- a/Sources/CommandLineTool/cap2spm.swift
+++ b/Sources/CommandLineTool/cap2spm.swift
@@ -44,7 +44,9 @@ struct Cap2SPM: ParsableCommand {
         let packageGenerator = PackageFileGenerator(packageName: podspec.podName, targetName: capPlugin.identifier)
         
         try packageGenerator.generateFile(at: podspecFileURL)
-        
+
+        try podspec.modifyPodspecFile(at: podspecFileURL)
+
         var unneededFiles = [hFileURL, mFileURL]
         let oldFiles = ["Plugin/Info.plist",
                         "PluginTests/Info.plist",


### PR DESCRIPTION
It was implemented in https://github.com/ionic-team/capacitor-plugin-converter/pull/8, but got deleted in the recent refactor.

I've put the code inside the PodspecParser class now since cap2spm removed all methods in the refactor and didn't want to add new ones, but could move it somewhere else.