### PR TITLE
Revert "chore: update swift, iOS, and Capacitor versions"

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,22 +1,22 @@
 {
-  "originHash" : "8c2c0fe9d1f6bedc473e4f68ef62f559cd23d9658b65273d8b9e321d658236ec",
+  "originHash" : "1929e04a0f6bfe5d9e730a8057ac5dc95f50cac50ac5397177d58efbdc4eec7c",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
-        "version" : "1.6.1"
+        "revision" : "011f0c765fb46d9cac61bca19be0527e99c98c8b",
+        "version" : "1.5.1"
       }
     },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "21b3b45635decd1a0b89968f81b6d9a93128f773",
-        "version" : "602.0.0-prerelease-2025-08-11"
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -7,9 +7,9 @@ let package = Package(
     name: "capacitor-plugin-converter",
     platforms: [.macOS(.v15)],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.6.1"),
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0-prerelease-2025-08-11"),
-        .package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git", from: "5.0.2"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.1"),
+        .package(url: "https://github.com/apple/swift-syntax.git", from: "601.0.1"),
+        .package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git", from: "5.0.0"),
     ],
     targets: [
         .executableTarget(

--- a/Sources/CapacitorPluginTools/PackageFileGenerator.swift
+++ b/Sources/CapacitorPluginTools/PackageFileGenerator.swift
@@ -5,16 +5,16 @@ public class PackageFileGenerator {
     let targetName: String
     let capRepoName = "capacitor-swift-pm"
     let capLocation = "https://github.com/ionic-team/capacitor-swift-pm.git"
-    let capVersion = "8.0.0"
+    let capVersion = "7.0.0"
 
     var packageText: String {
         return """
-            // swift-tools-version: 6.1
+            // swift-tools-version: 5.9
             import PackageDescription
 
             let package = Package(
                 name: "\(packageName)",
-                platforms: [.iOS(.v15)],
+                platforms: [.iOS(.v14)],
                 products: [
                     .library(
                         name: "\(packageName)",

--- a/Tests/CapacitorPluginToolsTests/PackageFileGenerator.swift
+++ b/Tests/CapacitorPluginToolsTests/PackageFileGenerator.swift
@@ -15,19 +15,19 @@ struct PackageFileGeneratorTests {
     }
     
     let expected = """
-        // swift-tools-version: 6.1
+        // swift-tools-version: 5.9
         import PackageDescription
 
         let package = Package(
             name: "CapacitorAppPlugin",
-            platforms: [.iOS(.v15)],
+            platforms: [.iOS(.v14)],
             products: [
                 .library(
                     name: "CapacitorAppPlugin",
                     targets: ["AppPlugin"])
             ],
             dependencies: [
-                .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0")
+                .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
             ],
             targets: [
                 .target(


### PR DESCRIPTION
Capacitor 8.0.0 is not out there yet, so https://github.com/ionic-team/capacitor-plugin-converter/commit/89519e1ad646d2e154f03feff53db84d5738e3ac breaks the converter as the converted plugin will try to fetch a version that doesn't exist, we can't do such change until Capacitor 8.0.0 is released.

This reverts commit 89519e1ad646d2e154f03feff53db84d5738e3ac.