### PR TITLE
fix: handle package.json content as string

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
                     dependencies: [
                         .target(name: "JavascriptPackageTools"),
                     ],
-                    resources: [.copy("../Resources/package-new.json")]
+                    resources: [.copy("../Resources/package-new.json"), .copy("../Resources/package-old.json")]
         ),
         .testTarget(name: "CapacitorPluginSyntaxToolsTests",
                 dependencies: [

--- a/Sources/CapacitorPluginTools/CapacitorPluginPackage.swift
+++ b/Sources/CapacitorPluginTools/CapacitorPluginPackage.swift
@@ -147,18 +147,7 @@ public class CapacitorPluginPackage {
         try? packageJSONParser.changeScript(named: "verify:ios",
                                            to: "xcodebuild -scheme \(podName) -destination generic/platform=iOS")
         
-        var newFiles = packageJSONParser.files
-        
-        newFiles.removeAll(where: { $0 == "ios/Plugin" || $0 == "ios/Plugin/" })
-        
-        if !newFiles.contains(where: { $0 == "ios/"}) {
-            newFiles.append("ios/Sources")
-            newFiles.append("ios/Tests")
-        }
-        
-        newFiles.append("Package.swift")
-        
-        packageJSONParser.files = newFiles
+        packageJSONParser.setFiles()
         
         try packageJSONParser.writePackageJSON()
     }

--- a/Tests/JavascriptPackageToolsTests/PackageJSONParserTests.swift
+++ b/Tests/JavascriptPackageToolsTests/PackageJSONParserTests.swift
@@ -3,33 +3,44 @@ import Foundation
 import JavascriptPackageTools
 
 struct PackageJSONParserTests {
-    let packageJSONParser: PackageJSONParser
+    let newPackageJSONParser: PackageJSONParser
+    let oldPackageJSONParser: PackageJSONParser
     
     init() throws {
-        let testJSON = try #require(Bundle.module.url(forResource: "package-new", withExtension: "json"))
-        packageJSONParser = try PackageJSONParser(with: testJSON)
+        let newJSON = try #require(Bundle.module.url(forResource: "package-new", withExtension: "json"))
+        let oldJSON = try #require(Bundle.module.url(forResource: "package-old", withExtension: "json"))
+        newPackageJSONParser = try PackageJSONParser(with: newJSON)
+        oldPackageJSONParser = try PackageJSONParser(with: oldJSON)
     }
     
     @Test("Correctly finds the podspec")
     func findsPodSpec() async throws {
-        #expect(packageJSONParser.podspec == "Typical.podspec")
+        #expect(newPackageJSONParser.podspec == "Typical.podspec")
     }
     
     @Test("Can change scripts")
     func canChangeScript() async throws {
-        var parser = packageJSONParser
-        let oldString = try #require(parser.jsonString)
-        try parser.changeScript(named: "verify:ios", to: "new-test")
-        let calculatedSting = try #require(parser.jsonString)
+        var parser = oldPackageJSONParser
+        let oldString = parser.jsonString
+        try parser.changeScript(named: "verify:ios", to: "xcodebuild build -scheme TypicalPlugin -destination generic/platform=iOS")
+        let calculatedSting = parser.jsonString
         #expect(calculatedSting != oldString)
     }
     
     @Test("Can change files")
     func canSetFiles() async throws {
-        var parser = packageJSONParser
-        let oldString = try #require(parser.jsonString)
-        parser.files = ["new", "list", "files"]
-        let calculatedSting = try #require(parser.jsonString)
+        var parser = oldPackageJSONParser
+        let oldString = parser.jsonString
+        parser.setFiles()
+        let calculatedSting = parser.jsonString
         #expect(calculatedSting != oldString)
+    }
+
+    @Test("Full package update")
+    func replacedFilesAndScripts() async throws {
+        var oldParser = oldPackageJSONParser
+        try oldParser.changeScript(named: "verify:ios", to: "xcodebuild build -scheme TypicalPlugin -destination generic/platform=iOS")
+        oldParser.setFiles()
+        #expect(newPackageJSONParser.jsonString == oldParser.jsonString)
     }
 }

--- a/Tests/Resources/package-old.json
+++ b/Tests/Resources/package-old.json
@@ -1,81 +1,73 @@
 {
-  "name": "@capacitor/google-maps",
-  "version": "7.0.2",
-  "description": "Google maps on Capacitor",
+  "name": "@capacitor/typicalplugin",
+  "version": "7.0.1",
+  "description": "Does some things",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",
-  "typings": "dist/typings/index.d.ts",
-  "typesVersions": {
-    "<4.1": {
-      "dist/typings/index.d.ts": [
-        "dist/typings/ts_old/index.d.ts"
-      ]
-    }
-  },
+  "types": "dist/esm/index.d.ts",
   "unpkg": "dist/plugin.js",
   "files": [
     "android/src/main/",
     "android/build.gradle",
     "dist/",
     "ios/Plugin/",
-    "CapacitorGoogleMaps.podspec"
+    "Typical.podspec"
   ],
   "author": "Ionic <hi@ionicframework.com>",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ionic-team/capacitor-google-maps.git"
+    "url": "git+https://github.com/ionic-team/capacitor-plugins.git"
   },
   "bugs": {
-    "url": "https://github.com/ionic-team/capacitor-google-maps/issues"
+    "url": "https://github.com/ionic-team/capacitor-plugins/issues"
   },
   "keywords": [
     "capacitor",
     "plugin",
-    "native",
-    "google-maps"
+    "native"
   ],
   "scripts": {
-    "verify": "pnpm run verify:ios && pnpm run verify:android && pnpm run verify:web",
+    "verify": "npm run verify:ios && npm run verify:android && npm run verify:web",
     "verify:ios": "cd ios && pod install && xcodebuild -workspace Plugin.xcworkspace -scheme Plugin -sdk iphonesimulator && cd ..",
     "verify:android": "cd android && ./gradlew clean build test && cd ..",
-    "verify:web": "pnpm run build",
-    "lint": "pnpm eslint . --ext ts && pnpm prettier \"./**/*.{css,html,ts,js,java}\" --check && pnpm node-swiftlint lint",
-    "fmt": "pnpm eslint . --ext ts --fix && pnpm prettier \"./**/*.{css,html,ts,js,java}\" --write && pnpm node-swiftlint --fix --format",
-    "docgen": "docgen --api GoogleMapInterface --output-readme README.md --output-json dist/docs.json",
-    "build": "pnpm run clean && pnpm run docgen && tsc && rollup -c rollup.config.js && pnpm run downleveldts",
+    "verify:web": "npm run build",
+    "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
+    "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
+    "eslint": "eslint . --ext ts",
+    "prettier": "prettier \"**/*.{css,html,ts,js,java}\"",
+    "swiftlint": "node-swiftlint",
+    "docgen": "docgen --api TypicalPlugin --output-readme README.md --output-json dist/docs.json",
+    "build": "npm run clean && npm run docgen && tsc && rollup -c rollup.config.mjs",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
-    "prepublishOnly": "pnpm run build",
-    "publish:cocoapod": "pod trunk push ./CapacitorGoogleMaps.podspec --allow-warnings",
-    "downleveldts": "pnpm downlevel-dts dist/typings dist/typings/ts_old --to=3.5",
-    "pack-local": "pnpm run build && pnpm pack && find . -name 'capacitor-google-maps-*tgz' -exec bash -c 'mv $0 capacitor-google-maps.tgz' {} \\; ",
-    "unittest:ios": "xcodebuild test -project ./unit-tests/ios/GoogleMapsPlugin/GoogleMapsPlugin.xcodeproj -scheme TestApp -destination 'platform=iOS Simulator,name=iPhone 12,OS=15.2' | xcpretty && exit ${PIPESTATUS[0]}",
-    "unittest:android": "cd ./unit-tests/android && ./gradlew testDebugUnitTest"
+    "prepublishOnly": "npm run build",
+    "publish:cocoapod": "pod trunk push ./Typical.podspec --allow-warnings"
   },
   "devDependencies": {
     "@capacitor/android": "next",
+    "@capacitor/cli": "^6.0.0",
     "@capacitor/core": "next",
-    "@capacitor/docgen": "0.3.0",
+    "@capacitor/docgen": "0.2.2",
     "@capacitor/ios": "next",
-    "@ionic/prettier-config": "^1.0.1",
-    "@types/resize-observer-browser": "^0.1.7",
-    "@types/supercluster": "^7.1.0",
-    "@typescript-eslint/eslint-plugin": "^5.59.2",
-    "@typescript-eslint/parser": "^5.59.2",
-    "downlevel-dts": "^0.7.0",
+    "@ionic/eslint-config": "^0.4.0",
+    "@ionic/prettier-config": "~1.0.1",
+    "@ionic/swiftlint-config": "^1.1.2",
     "eslint": "^8.57.0",
-    "eslint-config-prettier": "^8.8.0",
-    "eslint-plugin-import": "^2.25.4",
-    "prettier": "^2.8.8",
-    "prettier-plugin-java": "~2.1.0",
-    "rimraf": "^3.0.2",
-    "rollup": "^2.78.1",
-    "swiftlint": "^1.0.2",
-    "typescript": "^5.4.2"
+    "prettier": "~2.3.0",
+    "prettier-plugin-java": "~1.0.2",
+    "rimraf": "^6.0.1",
+    "rollup": "^4.26.0",
+    "swiftlint": "^1.0.1",
+    "typescript": "~4.1.5"
   },
   "peerDependencies": {
     "@capacitor/core": ">=7.0.0"
+  },
+  "prettier": "@ionic/prettier-config",
+  "swiftlint": "@ionic/swiftlint-config",
+  "eslintConfig": {
+    "extends": "@ionic/eslint-config/recommended"
   },
   "capacitor": {
     "ios": {
@@ -87,10 +79,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "dependencies": {
-    "@googlemaps/js-api-loader": "~1.16.8",
-    "@googlemaps/markerclusterer": "~2.5.3",
-    "@types/google.maps": "~3.58.1"
   }
 }


### PR DESCRIPTION
handle the package.json content as string to avoid the undesired reformatting 
add `package-old.json` correctly to the project and change its content to be the same as `package-new.json` except for the `verify:ios` script and files, and add a test that compares them both after the conversion to make sure they look the same.

removed the setters/mutations from `PackageJSONParser.swift` other than the jsonString